### PR TITLE
Support whitespace in timezone names

### DIFF
--- a/timezones/info.plist
+++ b/timezones/info.plist
@@ -100,7 +100,7 @@ try:
 except (OSError, IOError):
     shortlist = pytz.all_timezones
 
-query = sys.argv[1]
+query = sys.argv[1].replace(' ', '_')
 timezones = filter(lambda tz: query in tz.lower(), pytz.all_timezones) if query else shortlist
 
 results = []


### PR DESCRIPTION
This replaces spaces in timezone names with underscores, allowing `new york` to match `America/New_York`, etc.